### PR TITLE
Fix: Create variant for source script directories to use for intellij/vscode integration

### DIFF
--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptAttributes.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptAttributes.java
@@ -27,12 +27,12 @@ public interface TypeScriptAttributes {
     String MODULE = "module";
 
     /**
-     * Ued with {@link org.gradle.api.attributes.LibraryElements}.
+     * Used with {@link org.gradle.api.attributes.LibraryElements}.
      */
     String PACKAGE_JSON = "package-json";
 
     /**
-     * Ued with {@link org.gradle.api.attributes.LibraryElements}.
+     * Used with {@link org.gradle.api.attributes.LibraryElements}.
      */
     String SOURCE_SCRIPT_DIRS = "source-script-dirs";
 }

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptAttributes.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptAttributes.java
@@ -30,4 +30,9 @@ public interface TypeScriptAttributes {
      * Ued with {@link org.gradle.api.attributes.LibraryElements}.
      */
     String PACKAGE_JSON = "package-json";
+
+    /**
+     * Ued with {@link org.gradle.api.attributes.LibraryElements}.
+     */
+    String SOURCE_SCRIPT_DIRS = "source-script-dirs";
 }

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptAttributes.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptAttributes.java
@@ -27,7 +27,8 @@ public interface TypeScriptAttributes {
     String MODULE = "module";
 
     /**
-     * Used with {@link org.gradle.api.attributes.LibraryElements}.
+     * Used with {@link org.gradle.api.internal.artifacts.ArtifactAttributes}
+     * and {@link org.gradle.api.attributes.LibraryElements}.
      */
     String PACKAGE_JSON = "package-json";
 

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
@@ -28,6 +28,7 @@ import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.Directory;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.artifacts.ArtifactAttributes;
 import org.gradle.api.model.ObjectFactory;
@@ -134,21 +135,19 @@ public final class TypeScriptBasePlugin implements Plugin<Project> {
                 .register(sourceSet.getCreateTsConfigTaskName(), CreateTsConfigTask.class, createTsConfigTask -> {
                     createTsConfigTask.setGroup(LifecycleBasePlugin.BUILD_TASK_NAME);
                     createTsConfigTask.setDescription("Creates vscode tsconfig.json for " + sourceSet.getName());
-                    createTsConfigTask
-                            .getCompileClasspath()
-                            .from(project.getConfigurations()
-                                    .getByName(sourceSet.getCompileConfigurationName())
-                                    .getIncoming()
-                                    .artifactView(v -> v.getAttributes()
-                                            .attribute(
-                                                    LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-                                                    project.getObjects()
-                                                            .named(
-                                                                    LibraryElements.class,
-                                                                    TypeScriptAttributes.SOURCE_SCRIPT_DIRS))
-                                            .attribute(ArtifactAttributes.ARTIFACT_FORMAT, TypeScriptAttributes.MODULE))
-                                    .getArtifacts()
-                                    .getArtifactFiles());
+                    FileCollection configClasspathh = project.getConfigurations()
+                            .getByName(sourceSet.getCompileConfigurationName())
+                            .getIncoming()
+                            .artifactView(v -> {
+                                LibraryElements sourceScriptDirs = project.getObjects()
+                                        .named(LibraryElements.class, TypeScriptAttributes.SOURCE_SCRIPT_DIRS);
+                                v.getAttributes()
+                                        .attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, sourceScriptDirs)
+                                        .attribute(ArtifactAttributes.ARTIFACT_FORMAT, TypeScriptAttributes.MODULE);
+                            })
+                            .getArtifacts()
+                            .getArtifactFiles();
+                    createTsConfigTask.getCompileClasspath().from(configClasspathh);
                     createTsConfigTask
                             .getSourceDirectories()
                             .set(sourceSet.getSource().getSrcDirs());

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
@@ -25,9 +25,11 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.artifacts.ArtifactAttributes;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.ReportingBasePlugin;
@@ -129,7 +131,19 @@ public final class TypeScriptBasePlugin implements Plugin<Project> {
                     createTsConfigTask.setDescription("Creates vscode tsconfig.json for " + sourceSet.getName());
                     createTsConfigTask
                             .getCompileClasspath()
-                            .set(project.getConfigurations().named(sourceSet.getCompileConfigurationName()));
+                            .from(project.getConfigurations()
+                                    .getByName(sourceSet.getCompileConfigurationName())
+                                    .getIncoming()
+                                    .artifactView(v -> v.getAttributes()
+                                            .attribute(
+                                                    LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                                                    project.getObjects()
+                                                            .named(
+                                                                    LibraryElements.class,
+                                                                    TypeScriptAttributes.SOURCE_SCRIPT_DIRS))
+                                            .attribute(ArtifactAttributes.ARTIFACT_FORMAT, TypeScriptAttributes.MODULE))
+                                    .getArtifacts()
+                                    .getArtifactFiles());
                     createTsConfigTask
                             .getSourceDirectories()
                             .set(sourceSet.getSource().getSrcDirs());
@@ -140,7 +154,7 @@ public final class TypeScriptBasePlugin implements Plugin<Project> {
                     createTsConfigTask.getCompilerOptions().value(compilerOptions);
                     createTsConfigTask
                             .getTypeRoots()
-                            .from(project.getConfigurations().named(sourceSet.getCompileTypesConfigurationName()));
+                            .from(project.getConfigurations().getByName(sourceSet.getCompileTypesConfigurationName()));
                     createTsConfigTask.getTsConfig().set(project.file("src/" + sourceSet.getName() + "/tsconfig.json"));
                     createTsConfigTask.onlyIf(new Spec<Task>() {
                         @Override

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
@@ -92,6 +92,11 @@ public final class TypeScriptBasePlugin implements Plugin<Project> {
         compileConfiguration
                 .getAttributes()
                 .attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
+        compileConfiguration
+                .getAttributes()
+                .attribute(
+                        LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                        objectFactory.named(LibraryElements.class, TypeScriptAttributes.MODULE));
         // TODO(forozco): propogate type dependencies
         sourceSet.getCompileClasspath().from(compileConfiguration);
 

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptPlugin.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptPlugin.java
@@ -218,7 +218,6 @@ public class TypeScriptPlugin implements Plugin<Project> {
 
         ConfigurationVariantInternal variant = (ConfigurationVariantInternal)
                 configuration.getOutgoing().getVariants().create("source-script-dirs");
-        variant.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, TypeScriptAttributes.MODULE);
         variant.getAttributes()
                 .attribute(
                         LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/CreateTsConfigTask.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/CreateTsConfigTask.java
@@ -17,23 +17,15 @@
 package com.gradlets.gradle.typescript.idea;
 
 import com.gradlets.gradle.typescript.ObjectMappers;
-import com.gradlets.gradle.typescript.PackageJsonExtension;
 import com.gradlets.gradle.typescript.TypeScriptConfigs;
-import com.gradlets.gradle.typescript.TypeScriptPluginExtension;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.artifacts.result.ComponentResult;
-import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
@@ -41,7 +33,6 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -60,9 +51,6 @@ public abstract class CreateTsConfigTask extends DefaultTask {
                     .dir("tsconfigs")
                     .map(dir -> dir.file(String.format("tsconfig-%s.json", tsConfigName.get()))));
 
-    @Internal
-    public abstract Property<Configuration> getCompileClasspath();
-
     @InputFiles
     public abstract SetProperty<File> getSourceDirectories();
 
@@ -78,17 +66,12 @@ public abstract class CreateTsConfigTask extends DefaultTask {
     }
 
     @InputFiles
-    @PathSensitive(PathSensitivity.ABSOLUTE)
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract ConfigurableFileCollection getTypeRoots();
 
-    @Input
-    final Set<String> getRuntimeClasspathConfig() {
-        // serializable way of representing all dependencies without forcing compilation to occur in dependency projects
-        return getCompileClasspath().get().getIncoming().getResolutionResult().getAllComponents().stream()
-                .map(ComponentResult::getId)
-                .map(ComponentIdentifier::getDisplayName)
-                .collect(Collectors.toSet());
-    }
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getCompileClasspath();
 
     @OutputFile
     public final RegularFileProperty getTsConfig() {
@@ -97,39 +80,24 @@ public abstract class CreateTsConfigTask extends DefaultTask {
 
     @TaskAction
     public final void generateTsConfig() throws IOException {
-        Configuration classpath = getCompileClasspath().get();
-        Set<File> dependenciesFiles = classpath.getIncoming().getArtifacts().getArtifacts().stream()
-                .filter(resolvedArtifact ->
-                        !(resolvedArtifact.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier))
-                .map(ResolvedArtifactResult::getFile)
-                .collect(Collectors.toUnmodifiableSet());
-        Map<String, List<Path>> projectDeps = classpath.getIncoming().getResolutionResult().getAllComponents().stream()
-                .map(ComponentResult::getId)
-                .filter(ProjectComponentIdentifier.class::isInstance)
-                .map(ProjectComponentIdentifier.class::cast)
-                .map(ProjectComponentIdentifier::getProjectPath)
-                .map(projectPath -> getProject().findProject(projectPath))
-                .filter(Objects::nonNull)
-                .filter(projectDep -> projectDep.getExtensions().findByType(TypeScriptPluginExtension.class) != null
-                        && projectDep.getExtensions().findByType(PackageJsonExtension.class) != null)
-                .collect(Collectors.toMap(
-                        projectDep -> {
-                            PackageJsonExtension packageJsonExtension =
-                                    projectDep.getExtensions().findByType(PackageJsonExtension.class);
-                            return !packageJsonExtension.getScope().get().equals("")
-                                    ? "@" + packageJsonExtension.getScope().get() + "/" + projectDep.getName()
-                                    : projectDep.getName();
-                        },
-                        projectDep -> projectDep
-                                .getExtensions()
-                                .findByType(TypeScriptPluginExtension.class)
-                                .getSourceSets()
-                                .getByName("main")
-                                .getSource()
-                                .getSrcDirs()
-                                .stream()
-                                .map(File::toPath)
-                                .collect(Collectors.toUnmodifiableList())));
+        Set<File> dependenciesFiles = getCompileClasspath()
+                .filter(element -> !element.getAbsolutePath()
+                        .startsWith(
+                                getProject().getRootProject().getProjectDir().getAbsolutePath()))
+                .getFiles();
+
+        Map<String, List<Path>> projectDepsFiles = getCompileClasspath()
+                .filter(element -> element.getAbsolutePath()
+                        .startsWith(
+                                getProject().getRootProject().getProjectDir().getAbsolutePath()))
+                .getFiles()
+                .stream()
+                .map(File::toPath)
+                .map(path ->
+                        getProject().getRootProject().getProjectDir().toPath().relativize(path))
+                .collect(Collectors.groupingBy(
+                        path -> path.getName(0).toString(),
+                        Collectors.mapping(Path::toAbsolutePath, Collectors.toUnmodifiableList())));
 
         GFileUtils.parentMkdirs(tsConfig.get().getAsFile());
         File tsConfigFile = tsConfig.getAsFile().get();
@@ -141,7 +109,7 @@ public abstract class CreateTsConfigTask extends DefaultTask {
                                         tsConfigFile.toPath().getParent().relativize(sourceDir.toPath()))
                                 .collect(Collectors.toUnmodifiableSet()),
                         getOutputDir().get().toPath(),
-                        projectDeps,
+                        projectDepsFiles,
                         dependenciesFiles,
                         getTypeRoots().getFiles(),
                         getCompilerOptions().get()));

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/CreateTsConfigTask.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/CreateTsConfigTask.java
@@ -80,7 +80,7 @@ public abstract class CreateTsConfigTask extends DefaultTask {
 
     @TaskAction
     public final void generateTsConfig() throws IOException {
-        Set<File> dependenciesFiles = getCompileClasspath()
+        Set<File> externalDependencyFiles = getCompileClasspath()
                 .filter(element -> !element.getAbsolutePath()
                         .startsWith(
                                 getProject().getRootProject().getProjectDir().getAbsolutePath()))
@@ -110,7 +110,7 @@ public abstract class CreateTsConfigTask extends DefaultTask {
                                 .collect(Collectors.toUnmodifiableSet()),
                         getOutputDir().get().toPath(),
                         projectDepsFiles,
-                        dependenciesFiles,
+                        externalDependencyFiles,
                         getTypeRoots().getFiles(),
                         getCompilerOptions().get()));
     }

--- a/gradle-typescript/src/test/groovy/com/gradlets/gradle/typescript/CreateTsConfigIntegrationTest.groovy
+++ b/gradle-typescript/src/test/groovy/com/gradlets/gradle/typescript/CreateTsConfigIntegrationTest.groovy
@@ -121,7 +121,11 @@ class CreateTsConfigIntegrationTest extends IntegrationSpec {
         Map<String, Set<String>> paths = (ObjectMappers.MAPPER.readValue(
                 file('third/src/test/tsconfig.json'), TsConfig.class)
                 .compilerOptions()
-                .get("paths") as Map<String, Set<String>>)
+                .get('paths') as Map<String, Set<String>>)
         paths.containsKey('conjure-client')
+        ['first', 'second', 'third'].forEach {
+            paths.containsKey(it)
+            paths.containsKey(it + "/*")
+        }
     }
 }


### PR DESCRIPTION
This avoid race condition when CreateTsConfig task would try to resolve dependencies and trigger NpmArtifactTransfomer that would end up reading corrupted file due to lack of task dependencies