### PR TITLE
Feature: Add ability to specify jest presets

### DIFF
--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/DefaultJestExtension.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/DefaultJestExtension.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2021 Felipe Orozco, Robert Kruszewski. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradlets.gradle.typescript;
+
+import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+
+public class DefaultJestExtension implements JestExtension {
+    private static final String EXTENSION_NAME = "jest";
+
+    private final Property<String> preset;
+
+    public DefaultJestExtension(ObjectFactory objects) {
+        preset = objects.property(String.class).value("ts-jest");
+    }
+
+    static JestExtension register(Project project) {
+        return project.getExtensions()
+                .create(JestExtension.class, EXTENSION_NAME, DefaultJestExtension.class, project.getObjects());
+    }
+
+    @Override
+    public final Property<String> getPreset() {
+        return preset;
+    }
+}

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/JestExtension.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/JestExtension.java
@@ -1,0 +1,23 @@
+/*
+ * (c) Copyright 2021 Felipe Orozco, Robert Kruszewski. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradlets.gradle.typescript;
+
+import org.gradle.api.provider.Property;
+
+public interface JestExtension {
+    Property<String> getPreset();
+}

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/JestTestSupport.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/JestTestSupport.java
@@ -16,6 +16,7 @@
 
 package com.gradlets.gradle.typescript;
 
+import java.util.Set;
 import org.gradle.api.Project;
 
 public final class JestTestSupport {
@@ -23,57 +24,37 @@ public final class JestTestSupport {
     private JestTestSupport() {}
 
     static void addDependencyConstraints(Project project, SourceSet testSourceSet) {
+        Set<String> coordinatesToConstraint = Set.of(
+                "npm:types/node:14.6.2",
+                "npm:types/istanbul-lib-report:3.0.0",
+                "npm:types/yargs-parser:20.2.0",
+                "npm:types/babel__generator:7.6.2",
+                "npm:types/babel__template:7.4.0",
+                "npm:inherits:2.0.4",
+                "npm:wrappy:1.0.2",
+                "npm:source-map-support:0.5.19",
+                "npm:bs-logger:0.2.6",
+                "npm:fast-json-stable-stringify:2.1.0",
+                "npm:semver:7.3.5",
+                "npm:json5:2.2.0",
+                "npm:make-error:1.3.6",
+                "npm:mkdirp:1.0.4",
+                "npm:yargs-parser:20.2.7",
+                "npm:lodash:4.17.21",
+                "npm:buffer-from:1.1.1");
+        Set<String> typesCoordinatesToConstraint =
+                Set.of("npm:types/yargs-parser:20.2.0", "npm:types/istanbul-lib-report:3.0.0");
         project.getConfigurations()
                 .named(testSourceSet.getCompileConfigurationName())
                 .configure(conf -> {
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:types/node:14.6.2"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies()
-                                    .getConstraints()
-                                    .create("npm:types/istanbul-lib-report:3.0.0"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:types/yargs-parser:20.2.0"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:types/babel__generator:7.6.2"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:types/babel__template:7.4.0"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:inherits:2.0.4"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:wrappy:1.0.2"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:source-map-support:0.5.19"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:bs-logger:0.2.6"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies()
-                                    .getConstraints()
-                                    .create("npm:fast-json-stable-stringify:2.1.0"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:semver:7.3.5"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:json5:2.2.0"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:make-error:1.3.6"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:mkdirp:1.0.4"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:yargs-parser:20.2.7"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:lodash:4.17.21"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:buffer-from:1.1.1"));
+                    coordinatesToConstraint.forEach(coord -> conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create(coord)));
                 });
         project.getConfigurations()
                 .named(testSourceSet.getCompileTypesConfigurationName())
                 .configure(conf -> {
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies().getConstraints().create("npm:types/yargs-parser:20.2.0"));
-                    conf.getDependencyConstraints()
-                            .add(project.getDependencies()
-                                    .getConstraints()
-                                    .create("npm:types/istanbul-lib-report:3.0.0"));
+                    typesCoordinatesToConstraint.forEach(coord -> conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create(coord)));
                 });
     }
 }

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/JestTestSupport.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/JestTestSupport.java
@@ -20,40 +20,41 @@ import java.util.Set;
 import org.gradle.api.Project;
 
 public final class JestTestSupport {
+    private static final Set<String> COORDINATES_TO_CONSTRAINT = Set.of(
+            "npm:types/node:14.6.2",
+            "npm:types/istanbul-lib-report:3.0.0",
+            "npm:types/yargs-parser:20.2.0",
+            "npm:types/babel__generator:7.6.2",
+            "npm:types/babel__template:7.4.0",
+            "npm:inherits:2.0.4",
+            "npm:wrappy:1.0.2",
+            "npm:source-map-support:0.5.19",
+            "npm:bs-logger:0.2.6",
+            "npm:fast-json-stable-stringify:2.1.0",
+            "npm:semver:7.3.5",
+            "npm:json5:2.2.0",
+            "npm:make-error:1.3.6",
+            "npm:mkdirp:1.0.4",
+            "npm:yargs-parser:20.2.7",
+            "npm:lodash:4.17.21",
+            "npm:buffer-from:1.1.1");
+
+    private static final Set<String> TYPES_COORDINATES_TO_CONSTRAINT =
+            Set.of("npm:types/yargs-parser:20.2.0", "npm:types/istanbul-lib-report:3.0.0");
 
     private JestTestSupport() {}
 
     static void addDependencyConstraints(Project project, SourceSet testSourceSet) {
-        Set<String> coordinatesToConstraint = Set.of(
-                "npm:types/node:14.6.2",
-                "npm:types/istanbul-lib-report:3.0.0",
-                "npm:types/yargs-parser:20.2.0",
-                "npm:types/babel__generator:7.6.2",
-                "npm:types/babel__template:7.4.0",
-                "npm:inherits:2.0.4",
-                "npm:wrappy:1.0.2",
-                "npm:source-map-support:0.5.19",
-                "npm:bs-logger:0.2.6",
-                "npm:fast-json-stable-stringify:2.1.0",
-                "npm:semver:7.3.5",
-                "npm:json5:2.2.0",
-                "npm:make-error:1.3.6",
-                "npm:mkdirp:1.0.4",
-                "npm:yargs-parser:20.2.7",
-                "npm:lodash:4.17.21",
-                "npm:buffer-from:1.1.1");
-        Set<String> typesCoordinatesToConstraint =
-                Set.of("npm:types/yargs-parser:20.2.0", "npm:types/istanbul-lib-report:3.0.0");
         project.getConfigurations()
                 .named(testSourceSet.getCompileConfigurationName())
                 .configure(conf -> {
-                    coordinatesToConstraint.forEach(coord -> conf.getDependencyConstraints()
+                    COORDINATES_TO_CONSTRAINT.forEach(coord -> conf.getDependencyConstraints()
                             .add(project.getDependencies().getConstraints().create(coord)));
                 });
         project.getConfigurations()
                 .named(testSourceSet.getCompileTypesConfigurationName())
                 .configure(conf -> {
-                    typesCoordinatesToConstraint.forEach(coord -> conf.getDependencyConstraints()
+                    TYPES_COORDINATES_TO_CONSTRAINT.forEach(coord -> conf.getDependencyConstraints()
                             .add(project.getDependencies().getConstraints().create(coord)));
                 });
     }

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/JestTestSupport.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/JestTestSupport.java
@@ -1,0 +1,79 @@
+/*
+ * (c) Copyright 2021 Felipe Orozco, Robert Kruszewski. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gradlets.gradle.typescript;
+
+import org.gradle.api.Project;
+
+public final class JestTestSupport {
+
+    private JestTestSupport() {}
+
+    static void addDependencyConstraints(Project project, SourceSet testSourceSet) {
+        project.getConfigurations()
+                .named(testSourceSet.getCompileConfigurationName())
+                .configure(conf -> {
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:types/node:14.6.2"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies()
+                                    .getConstraints()
+                                    .create("npm:types/istanbul-lib-report:3.0.0"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:types/yargs-parser:20.2.0"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:types/babel__generator:7.6.2"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:types/babel__template:7.4.0"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:inherits:2.0.4"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:wrappy:1.0.2"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:source-map-support:0.5.19"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:bs-logger:0.2.6"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies()
+                                    .getConstraints()
+                                    .create("npm:fast-json-stable-stringify:2.1.0"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:semver:7.3.5"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:json5:2.2.0"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:make-error:1.3.6"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:mkdirp:1.0.4"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:yargs-parser:20.2.7"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:lodash:4.17.21"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:buffer-from:1.1.1"));
+                });
+        project.getConfigurations()
+                .named(testSourceSet.getCompileTypesConfigurationName())
+                .configure(conf -> {
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies().getConstraints().create("npm:types/yargs-parser:20.2.0"));
+                    conf.getDependencyConstraints()
+                            .add(project.getDependencies()
+                                    .getConstraints()
+                                    .create("npm:types/istanbul-lib-report:3.0.0"));
+                });
+    }
+}

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/JestTestTask.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/JestTestTask.java
@@ -29,6 +29,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
@@ -40,6 +41,9 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.GFileUtils;
 
 public abstract class JestTestTask extends SourceTask {
+    @Input
+    abstract Property<String> getPreset();
+
     @Classpath
     abstract ConfigurableFileCollection getClasspath();
 
@@ -81,14 +85,14 @@ public abstract class JestTestTask extends SourceTask {
     private Map<String, Object> createJestConfig() throws IOException {
         ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
         builder.put("rootDir", getProject().getProjectDir().getAbsolutePath());
+        builder.put("preset", getPreset().get());
         builder.put(
                 "globals",
                 // Pure hack wrt location of tsconfig
                 ImmutableMap.of(
                         "ts-jest",
                         ImmutableMap.of(
-                                "tsConfigFile",
-                                getTsconfigFile().get().getAsFile().getAbsolutePath())));
+                                "tsconfig", getTsconfigFile().get().getAsFile().getAbsolutePath())));
         // Required to specify js, jsx since the whitelist applies to all modules (including dependencies)
         builder.put("moduleFileExtensions", ImmutableList.of("js", "jsx", "ts", "tsx"));
         builder.put("testEnvironment", "node");

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
@@ -47,11 +47,11 @@ public final class TypeScriptBasePlugin implements Plugin<Project> {
         project.getPluginManager().apply(NpmBasePlugin.class);
         project.getPluginManager().apply(ReportingBasePlugin.class);
 
-        TypeScriptPluginExtension typeScriptPluginExtension = addExtensions(project);
+        TypeScriptPluginExtension typeScriptPluginExtension = addTypeScriptExtension(project);
         configureSourceSetDefaults(project, typeScriptPluginExtension);
     }
 
-    private TypeScriptPluginExtension addExtensions(Project project) {
+    private TypeScriptPluginExtension addTypeScriptExtension(Project project) {
         TypeScriptPluginExtension typeScriptPluginExtension = DefaultTypeScriptPluginExtension.register(project);
         project.getExtensions()
                 .add(SourceSetContainer.class, "typeScriptSourceSets", typeScriptPluginExtension.getSourceSets());

--- a/gradle-typescript/src/test/groovy/com/gradlets/gradle/typescript/JestTestTaskIntegrationSpec.groovy
+++ b/gradle-typescript/src/test/groovy/com/gradlets/gradle/typescript/JestTestTaskIntegrationSpec.groovy
@@ -33,16 +33,22 @@ class JestTestTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
     }
 
-    def "executes jest"() {
+    def 'executes jest'() {
         when:
         buildFile << """
         dependencies {
             testDeps 'npm:jest:26.6.3'
+            testDeps 'npm:ts-jest:26.5.5'
+            testDeps 'npm:typescript:4.2.3'
+            testTypes 'npm:types/jest:26.0.22'
         }
         """.stripIndent()
         file("src/test/typescript/foo.ts") << '''
             describe("foo", () => {
-                it("runs a test", () => {});
+                it("runs a test", () => {
+                    // @ts-ignore
+                    const test: string = "hello world";
+                });
             });
         '''.stripIndent()
 


### PR DESCRIPTION
By default configures ts-jest preset to support writing tests in typescript. You need to provide `typescript` and `ts-jest` dependencies on testDeps configuration to run typescript tests.