### PR TITLE
Fix: IDE integration correctly works across projects

### DIFF
--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
@@ -21,6 +21,7 @@ import com.gradlets.gradle.typescript.idea.CreateTsConfigTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Bundling;
@@ -126,42 +127,49 @@ public final class TypeScriptBasePlugin implements Plugin<Project> {
 
     private static void createTsConfigTaskForSourceSet(
             Project project, SourceSet sourceSet, MapProperty<String, Object> compilerOptions) {
-        project.getTasks()
-                .register(sourceSet.getCreateTsConfigTaskName(), CreateTsConfigTask.class, createTsConfigTask -> {
-                    createTsConfigTask.setGroup(LifecycleBasePlugin.BUILD_TASK_NAME);
-                    createTsConfigTask.setDescription("Creates vscode tsconfig.json for " + sourceSet.getName());
-                    FileCollection configClasspathh = project.getConfigurations()
-                            .getByName(sourceSet.getCompileConfigurationName())
-                            .getIncoming()
-                            .artifactView(v -> {
-                                LibraryElements sourceScriptDirs = project.getObjects()
-                                        .named(LibraryElements.class, TypeScriptAttributes.SOURCE_SCRIPT_DIRS);
-                                v.getAttributes()
-                                        .attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, sourceScriptDirs)
-                                        .attribute(ArtifactAttributes.ARTIFACT_FORMAT, TypeScriptAttributes.MODULE);
-                            })
-                            .getArtifacts()
-                            .getArtifactFiles();
-                    createTsConfigTask.getCompileClasspath().from(configClasspathh);
-                    createTsConfigTask
-                            .getSourceDirectories()
-                            .set(sourceSet.getSource().getSrcDirs());
-                    createTsConfigTask
-                            .getOutputDir()
-                            .set(sourceSet.getSource().getClassesDirectory().map(Directory::getAsFile));
-                    createTsConfigTask.getTsConfigName().set(sourceSet.getName());
-                    createTsConfigTask.getCompilerOptions().value(compilerOptions);
-                    createTsConfigTask
-                            .getTypeRoots()
-                            .from(project.getConfigurations().getByName(sourceSet.getCompileTypesConfigurationName()));
-                    createTsConfigTask.getTsConfig().set(project.file("src/" + sourceSet.getName() + "/tsconfig.json"));
-                    createTsConfigTask.onlyIf(new Spec<Task>() {
-                        @Override
-                        public boolean isSatisfiedBy(Task _task) {
-                            return !sourceSet.getSource().isEmpty();
-                        }
-                    });
-                });
+        LibraryElements sourceScriptDirs =
+                project.getObjects().named(LibraryElements.class, TypeScriptAttributes.SOURCE_SCRIPT_DIRS);
+
+        Configuration compileConfig = project.getConfigurations().getByName(sourceSet.getCompileConfigurationName());
+        ArtifactView externalArtifacts = compileConfig.getIncoming().artifactView(v -> {
+            v.getAttributes()
+                    .attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, sourceScriptDirs)
+                    .attribute(ArtifactAttributes.ARTIFACT_FORMAT, TypeScriptAttributes.MODULE);
+        });
+
+        FileCollection projectDependencies = project.getConfigurations()
+                .create(
+                        sourceSet.getCompileConfigurationName() + "forTsconfig",
+                        conf -> conf.extendsFrom(compileConfig))
+                .getIncoming()
+                .artifactView(view -> view.getAttributes()
+                        .attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, sourceScriptDirs)
+                        .attribute(ArtifactAttributes.ARTIFACT_FORMAT, "scripts"))
+                .getArtifacts()
+                .getArtifactFiles();
+
+        project.getTasks().register(sourceSet.getCreateTsConfigTaskName(), CreateTsConfigTask.class, task -> {
+            task.setGroup(LifecycleBasePlugin.BUILD_TASK_NAME);
+            task.setDescription("Creates vscode tsconfig.json for " + sourceSet.getName());
+
+            task.getCompileClasspath()
+                    .from(externalArtifacts.getArtifacts().getArtifactFiles())
+                    .from(projectDependencies);
+
+            task.getSourceDirectories().set(sourceSet.getSource().getSrcDirs());
+            task.getOutputDir().set(sourceSet.getSource().getClassesDirectory().map(Directory::getAsFile));
+            task.getTsConfigName().set(sourceSet.getName());
+            task.getCompilerOptions().set(compilerOptions);
+            task.getTypeRoots()
+                    .from(project.getConfigurations().getByName(sourceSet.getCompileTypesConfigurationName()));
+            task.getTsConfig().set(project.file("src/" + sourceSet.getName() + "/tsconfig.json"));
+            task.onlyIf(new Spec<Task>() {
+                @Override
+                public boolean isSatisfiedBy(Task _task) {
+                    return !sourceSet.getSource().isEmpty();
+                }
+            });
+        });
     }
 
     private static void createAssembleTask(SourceSet sourceSet, Project project) {
@@ -173,7 +181,7 @@ public final class TypeScriptBasePlugin implements Plugin<Project> {
         sourceSet.compiledBy(assembleTask);
     }
 
-    public static void configureOutputDirectoryForSourceSet(
+    private static void configureOutputDirectoryForSourceSet(
             SourceSet sourceSet, SourceDirectorySet sourceDirectorySet, Project project) {
         String sourceSetChildPath = "scripts/" + sourceSet.getName();
         sourceDirectorySet.setOutputDir(

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
@@ -138,7 +138,7 @@ public final class TypeScriptBasePlugin implements Plugin<Project> {
 
         ArtifactView projectArtifacts = compileConfig.getIncoming().artifactView(view -> view.getAttributes()
                 .attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, sourceScriptDirs)
-                .attribute(ArtifactAttributes.ARTIFACT_FORMAT, "scripts"));
+                .attribute(ArtifactAttributes.ARTIFACT_FORMAT, TypeScriptAttributes.SOURCE_SCRIPT_DIRS));
 
         project.getTasks().register(sourceSet.getCreateTsConfigTaskName(), CreateTsConfigTask.class, task -> {
             task.setGroup(LifecycleBasePlugin.BUILD_TASK_NAME);

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptBasePlugin.java
@@ -29,7 +29,6 @@ import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.Directory;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.artifacts.ArtifactAttributes;
 import org.gradle.api.model.ObjectFactory;
@@ -137,16 +136,9 @@ public final class TypeScriptBasePlugin implements Plugin<Project> {
                     .attribute(ArtifactAttributes.ARTIFACT_FORMAT, TypeScriptAttributes.MODULE);
         });
 
-        FileCollection projectDependencies = project.getConfigurations()
-                .create(
-                        sourceSet.getCompileConfigurationName() + "forTsconfig",
-                        conf -> conf.extendsFrom(compileConfig))
-                .getIncoming()
-                .artifactView(view -> view.getAttributes()
-                        .attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, sourceScriptDirs)
-                        .attribute(ArtifactAttributes.ARTIFACT_FORMAT, "scripts"))
-                .getArtifacts()
-                .getArtifactFiles();
+        ArtifactView projectArtifacts = compileConfig.getIncoming().artifactView(view -> view.getAttributes()
+                .attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, sourceScriptDirs)
+                .attribute(ArtifactAttributes.ARTIFACT_FORMAT, "scripts"));
 
         project.getTasks().register(sourceSet.getCreateTsConfigTaskName(), CreateTsConfigTask.class, task -> {
             task.setGroup(LifecycleBasePlugin.BUILD_TASK_NAME);
@@ -154,7 +146,7 @@ public final class TypeScriptBasePlugin implements Plugin<Project> {
 
             task.getCompileClasspath()
                     .from(externalArtifacts.getArtifacts().getArtifactFiles())
-                    .from(projectDependencies);
+                    .from(projectArtifacts.getArtifacts().getArtifactFiles());
 
             task.getSourceDirectories().set(sourceSet.getSource().getSrcDirs());
             task.getOutputDir().set(sourceSet.getSource().getClassesDirectory().map(Directory::getAsFile));

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptPlugin.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptPlugin.java
@@ -200,7 +200,9 @@ public class TypeScriptPlugin implements Plugin<Project> {
 
         ConfigurationVariantInternal sourceVariant = (ConfigurationVariantInternal)
                 configuration.getOutgoing().getVariants().create("source-script-dirs");
-        sourceVariant.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, "scripts");
+        sourceVariant
+                .getAttributes()
+                .attribute(ArtifactAttributes.ARTIFACT_FORMAT, TypeScriptAttributes.SOURCE_SCRIPT_DIRS);
         sourceVariant
                 .getAttributes()
                 .attribute(

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptPlugin.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/TypeScriptPlugin.java
@@ -198,13 +198,15 @@ public class TypeScriptPlugin implements Plugin<Project> {
                         project.getObjects().named(LibraryElements.class, TypeScriptAttributes.PACKAGE_JSON));
         resourcesVariant.artifact(packageJsonArtifact);
 
-        ConfigurationVariantInternal variant = (ConfigurationVariantInternal)
+        ConfigurationVariantInternal sourceVariant = (ConfigurationVariantInternal)
                 configuration.getOutgoing().getVariants().create("source-script-dirs");
-        variant.getAttributes()
+        sourceVariant.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, "scripts");
+        sourceVariant
+                .getAttributes()
                 .attribute(
                         LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
                         project.getObjects().named(LibraryElements.class, TypeScriptAttributes.SOURCE_SCRIPT_DIRS));
-        variant.artifactsProvider(() -> mainSourceSet.getSource().getSourceDirectories().getFiles().stream()
+        sourceVariant.artifactsProvider(() -> mainSourceSet.getSource().getSourceDirectories().getFiles().stream()
                 .map(sourceScriptDir -> new LazyPublishArtifact(project.provider(() -> sourceScriptDir)))
                 .collect(Collectors.toUnmodifiableList()));
     }

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/CreateTsConfigTask.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/CreateTsConfigTask.java
@@ -23,9 +23,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
@@ -81,22 +83,14 @@ public abstract class CreateTsConfigTask extends DefaultTask {
     @TaskAction
     public final void generateTsConfig() throws IOException {
         Set<File> externalDependencyFiles = getCompileClasspath()
-                .filter(element -> !element.getAbsolutePath()
-                        .startsWith(
-                                getProject().getRootProject().getProjectDir().getAbsolutePath()))
+                .filter(element -> !isProjectDependency(element))
                 .getFiles();
 
-        Map<String, List<Path>> projectDepsFiles = getCompileClasspath()
-                .filter(element -> element.getAbsolutePath()
-                        .startsWith(
-                                getProject().getRootProject().getProjectDir().getAbsolutePath()))
-                .getFiles()
-                .stream()
+        Map<String, List<Path>> projectDepsFiles = getCompileClasspath().getFiles().stream()
+                .filter(this::isProjectDependency)
                 .map(File::toPath)
-                .map(path ->
-                        getProject().getRootProject().getProjectDir().toPath().relativize(path))
                 .collect(Collectors.groupingBy(
-                        path -> path.getName(0).toString(),
+                        this::getProjectName,
                         Collectors.mapping(Path::toAbsolutePath, Collectors.toUnmodifiableList())));
 
         GFileUtils.parentMkdirs(tsConfig.get().getAsFile());
@@ -113,5 +107,22 @@ public abstract class CreateTsConfigTask extends DefaultTask {
                         externalDependencyFiles,
                         getTypeRoots().getFiles(),
                         getCompilerOptions().get()));
+    }
+
+    private String getProjectName(Path scriptPath) {
+        String projectPath = getRootProjectDir()
+                .relativize(scriptPath.getParent().getParent().getParent())
+                .toString();
+        return Optional.ofNullable(getProject().getRootProject().findProject(projectPath.replace("/", ":")))
+                .map(Project::getName)
+                .orElseThrow();
+    }
+
+    private boolean isProjectDependency(File file) {
+        return file.toPath().startsWith(getRootProjectDir());
+    }
+
+    private Path getRootProjectDir() {
+        return getProject().getRootProject().getProjectDir().toPath();
     }
 }

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/CreateTsConfigTask.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/CreateTsConfigTask.java
@@ -113,7 +113,7 @@ public abstract class CreateTsConfigTask extends DefaultTask {
         String projectPath = getRootProjectDir()
                 .relativize(scriptPath.getParent().getParent().getParent())
                 .toString();
-        return Optional.ofNullable(getProject().getRootProject().findProject(projectPath.replace("/", ":")))
+        return Optional.ofNullable(getProject().findProject(":" + projectPath.replace("/", ":")))
                 .map(Project::getName)
                 .orElseThrow();
     }

--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/CreateTsConfigTask.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/CreateTsConfigTask.java
@@ -18,6 +18,8 @@ package com.gradlets.gradle.typescript.idea;
 
 import com.gradlets.gradle.typescript.ObjectMappers;
 import com.gradlets.gradle.typescript.TypeScriptConfigs;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -113,9 +115,10 @@ public abstract class CreateTsConfigTask extends DefaultTask {
         String projectPath = getRootProjectDir()
                 .relativize(scriptPath.getParent().getParent().getParent())
                 .toString();
-        return Optional.ofNullable(getProject().findProject(":" + projectPath.replace("/", ":")))
+        String projectName = ":" + projectPath.replace("/", ":");
+        return Optional.ofNullable(getProject().findProject(projectName))
                 .map(Project::getName)
-                .orElseThrow();
+                .orElseThrow(() -> new SafeRuntimeException("Unable to find project", SafeArg.of("name", projectName)));
     }
 
     private boolean isProjectDependency(File file) {

--- a/gradle-typescript/src/test/groovy/com/gradlets/gradle/typescript/CreateTsConfigIntegrationTest.groovy
+++ b/gradle-typescript/src/test/groovy/com/gradlets/gradle/typescript/CreateTsConfigIntegrationTest.groovy
@@ -57,6 +57,23 @@ class CreateTsConfigIntegrationTest extends IntegrationSpec {
         paths.containsKey('child/*')
     }
 
+    def 'supports nested projects'() {
+        when:
+        buildFile << """
+            dependencies {
+                deps project(':nested:child')
+            }
+        """.stripIndent()
+        addSubproject('nested:child')
+        createFile('nested/child/src/main/typescript.ts')
+
+        then:
+        def result = runTasksSuccessfully('createTsConfig')
+        !result.wasExecuted(':nested:child:compileTypeScript')
+        Map<String, Set<String>> paths = getTsConfigPaths(file('src/main/tsconfig.json'))
+        paths.containsKey('child')
+    }
+
     def 'idea renders all tsconfigs'() {
         when:
         addSubproject("child")


### PR DESCRIPTION
## Before this PR
We ignored all project dependencies when constructing IDE tsconfigs

## After this PR
==COMMIT_MSG==
IDE integration correctly works across projects
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->