### PR TITLE
Fix: Stop using deprecated property

### DIFF
--- a/gradle-baseline-typescript/src/main/java/com/gradlets/baseline/typescript/BaselineWebpack.java
+++ b/gradle-baseline-typescript/src/main/java/com/gradlets/baseline/typescript/BaselineWebpack.java
@@ -53,7 +53,7 @@ public final class BaselineWebpack implements Plugin<Project> {
                             .set(tsExt.getSourceSets()
                                     .getByName("main")
                                     .getSource()
-                                    .getOutputDir()
+                                    .getDestinationDirectory()
                                     .toPath()
                                     .resolve("index.js")
                                     .toAbsolutePath()


### PR DESCRIPTION
## Before this PR

Applying the webpack plugin leads to errors like:
```
The SourceDirectorySet.outputDir property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the classesDirectory property instead. See https://docs.gradle.org/7.1.1/dsl/org.gradle.api.file.SourceDirectorySet.html#org.gradle.api.file.SourceDirectorySet:outputDir for more details.
        at org.gradle.api.internal.file.DefaultSourceDirectorySet.getOutputDir(DefaultSourceDirectorySet.java:202)
        at com.gradlets.baseline.typescript.BaselineWebpack.lambda$applyInternal$2(BaselineWebpack.java:56)
        at org.gradle.api.internal.DefaultMutationGuard$2.execute(DefaultMutationGuard.java:44)
        at org.gradle.api.internal.DefaultMutationGuard$2.execute(DefaultMutationGuard.java:44)
```

## After this PR

Stop using `outputDir`