### PR TITLE
Properly create typescript-compiler.xml file when running in IntelliJ

### DIFF
--- a/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/GradleTypeScriptRootIdeaPlugin.java
+++ b/gradle-typescript/src/main/java/com/gradlets/gradle/typescript/idea/GradleTypeScriptRootIdeaPlugin.java
@@ -120,6 +120,7 @@ public final class GradleTypeScriptRootIdeaPlugin implements Plugin<Project> {
             doc = dBuilder.newDocument();
             rootElement = doc.createElement("project");
             rootElement.setAttribute("version", "4");
+            doc.appendChild(rootElement);
         }
 
         configure.accept(rootElement);


### PR DESCRIPTION
When attempting to use IntelliJ in a project that used this plugin, the first gradle sync would succeed, but subsequent ones would fail, due to the the `typescript-compiler.xml` file being created with only the XML declaration but no contents. This properly writes the generated typescript data on file creation.