### PR TITLE
Do SSL better

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ jobs:
   circle-all:
     docker: [{ image: 'cimg/openjdk:17.0-node' }]
     environment:
-      NODE_OPTIONS: --openssl-legacy-provider
       CIRCLE_TEST_REPORTS: /home/circleci/junit
       CIRCLE_ARTIFACTS: /home/circleci/artifacts
     steps:
@@ -50,7 +49,6 @@ jobs:
   publish:
     docker: [{ image: 'cimg/openjdk:17.0-node' }]
     environment:
-      NODE_OPTIONS: --openssl-legacy-provider
       CIRCLE_TEST_REPORTS: /home/circleci/junit
       CIRCLE_ARTIFACTS: /home/circleci/artifacts
     steps:

--- a/gradle-baseline-typescript/build.gradle
+++ b/gradle-baseline-typescript/build.gradle
@@ -40,13 +40,6 @@ dependencies {
     annotationProcessor 'org.immutables:value'
 }
 
-test {
-    // Replace with real node version check
-    if (!System.env.CI) {
-        environment 'NODE_OPTIONS', '--openssl-legacy-provider'
-    }
-}
-
 pluginBundle {
     website = 'https://gradlets.com'
     vcsUrl = 'https://github.com/gradlets/gradle-typescript'

--- a/gradle-baseline-typescript/src/main/resources/webpack.template.js
+++ b/gradle-baseline-typescript/src/main/resources/webpack.template.js
@@ -30,6 +30,7 @@ module.exports = {
     output: {
         path: __OUTPUT_DIR__,
         filename: "bundle.js",
+        hashFunction: "xxhash64",
         library: "[name]"
     },
     module: {

--- a/gradle-typescript/build.gradle
+++ b/gradle-typescript/build.gradle
@@ -54,10 +54,6 @@ tasks.withType(JavaCompile) {
 }
 
 test {
-    // Replace with real node version check
-    if (!System.env.CI) {
-        environment 'NODE_OPTIONS', '--openssl-legacy-provider'
-    }
     jvmArgs '--add-opens', 'java.base/java.util=ALL-UNNAMED'
 }
 


### PR DESCRIPTION
#23 added a bunch of node "--openssl-legacy-provider" flags everywhere we use webpack because it bumped Node to v17 which included security fixes to the default ssl provider, which was a break.

Instead of using the legacy ssl provider we can fix this by updating the webpack output hashFunction: https://webpack.js.org/configuration/output/#outputhashfunction